### PR TITLE
Remove deprecated `:has_rdoc=` from gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,8 +45,6 @@ spec = Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3'
   s.add_dependency 'kramdown', '~> 2.0'
 
-  s.has_rdoc = true
-
   s.author = 'Thomas Leitner'
   s.email = 't_leitner@gmx.at'
   s.homepage = "https://github.com/kramdown/parser-gfm"


### PR DESCRIPTION
From RubyGems 3.0:
```
Gem::Specification#has_rdoc= is deprecated with no replacement.
It will be removed on or after 2018-12-01.
```