### PR TITLE
Fix strikethrough single or non-latin characters

### DIFF
--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -185,7 +185,7 @@ EOF
       define_parser(:codeblock_fenced_gfm, FENCED_CODEBLOCK_START, nil, 'parse_codeblock_fenced')
 
       STRIKETHROUGH_DELIM = /~~/
-      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}[^\s~](.*?)[^\s~]#{STRIKETHROUGH_DELIM}/m
+      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}(?!\s|~).*?[^\s~]#{STRIKETHROUGH_DELIM}/m
       define_parser(:strikethrough_gfm, STRIKETHROUGH_MATCH, '~~')
 
       def parse_strikethrough_gfm

--- a/test/testcases/strikethrough.html
+++ b/test/testcases/strikethrough.html
@@ -25,3 +25,7 @@ test<br />
 <p>This should ~~not be struck.</p>
 
 <p>This <del>is a complex <em>strike</em> through *test ~~with nesting</del> involved* here~~.</p>
+
+<p><del>中文</del></p>
+
+<p><del>a</del></p>

--- a/test/testcases/strikethrough.text
+++ b/test/testcases/strikethrough.text
@@ -25,3 +25,7 @@ I ~~don't even~~~ have an extra tilde.
 This should ~~not be struck.
 
 This ~~is a complex *strike* through *test ~~with nesting~~ involved* here~~.
+
+~~中文~~
+
+~~a~~


### PR DESCRIPTION
Resolves #8 

Strikethrough should work with single characters and non-latin characters

### Summary
  - Use negative lookahead to refute whitespace and `~`
  - Remove redundant capture-group since `kramdown` doesn't do anything with the captured string