### PR TITLE
Do not cast Symbols into strings to be re-casted

### DIFF
--- a/lib/kramdown/parser/gfm/options.rb
+++ b/lib/kramdown/parser/gfm/options.rb
@@ -51,9 +51,9 @@ module Kramdown
       Default: paragraph_end
       Used by: GFM parser
     EOF
-      val = simple_array_validator(val, :gfm_quirks)
-      val.map! { |v| str_to_sym(v.to_s) }
-      val
+      simple_array_validator(val, :gfm_quirks).map! do |v|
+        v.kind_of?(Symbol) ? v : str_to_sym(v.to_s)
+      end
     end
 
   end


### PR DESCRIPTION
Instead of *casting all values* into strings and then converting them to Symbols.

This change avoids unnecessary allocations from temporary strings.
For example, the default value `[:paragraph_end]` would first be converted into `["paragraph_end"]` temporarily and then back to `[:paragraph_end]` at the end.

/cc @gettalong 