### PR TITLE
Update parser to respect 'transliterated_header_ids' kramdown option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,6 +73,7 @@ task :gemfile do
       gem 'minitest', '~> 5.0'
       gem 'rouge', '~> 3.0'
       gem 'rubocop', '~> 0.62.0'
+      gem 'stringex', '~> 2.8.5'
     RUBY
   end
 end

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -63,6 +63,9 @@ module Kramdown
             update_text_type(element, child)
           elsif child.type == :html_element
             child
+          elsif child.type == :header && @options[:auto_ids] && @options[:transliterated_header_ids]
+            # Let the kramdown converter create the ID
+            child
           elsif child.type == :header && @options[:auto_ids] && !child.attr.key?('id')
             child.attr['id'] = generate_gfm_header_id(child.options[:raw_text])
             child

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -63,12 +63,14 @@ module Kramdown
             update_text_type(element, child)
           elsif child.type == :html_element
             child
-          elsif child.type == :header && @options[:auto_ids] && @options[:transliterated_header_ids]
-            # Let the kramdown converter create the ID
-            child
-          elsif child.type == :header && @options[:auto_ids] && !child.attr.key?('id')
-            child.attr['id'] = generate_gfm_header_id(child.options[:raw_text])
-            child
+          elsif child.type == :header && @options[:auto_ids]
+            if @options[:transliterated_header_ids]
+              # Let the kramdown converter create the ID
+              child
+            elsif !child.attr.key?('id')
+              child.attr['id'] = generate_gfm_header_id(child.options[:raw_text])
+              child
+            end
           else
             update_elements(child)
             child

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -63,14 +63,12 @@ module Kramdown
             update_text_type(element, child)
           elsif child.type == :html_element
             child
-          elsif child.type == :header && @options[:auto_ids]
-            if @options[:transliterated_header_ids]
-              # Let the kramdown converter create the ID
-              child
-            elsif !child.attr.key?('id')
-              child.attr['id'] = generate_gfm_header_id(child.options[:raw_text])
-              child
-            end
+          elsif child.type == :header && @options[:auto_ids] && @options[:transliterated_header_ids]
+            # Let the kramdown converter create the ID
+            child
+          elsif child.type == :header && @options[:auto_ids] && !child.attr.key?('id')
+            child.attr['id'] = generate_gfm_header_id(child.options[:raw_text])
+            child
           else
             update_elements(child)
             child

--- a/test/testcases/header_ids_with_transliteration.html
+++ b/test/testcases/header_ids_with_transliteration.html
@@ -1,0 +1,27 @@
+<h3 id="myid">test</h3>
+
+<h3 id="variablename">variable_name</h3>
+
+<h3 id="abc-def-ouss">abc def öúß</h3>
+
+<h3 id="abc-192">192 abc 192</h3>
+
+<h3 id="section">;.;;</h3>
+
+<h3 id="variablename-1">variable_name</h3>
+
+<h3 id="variablename-2">variable_name</h3>
+
+<h3 id="section-1">;;</h3>
+
+<h3 id="before-after-tab">before        after tab</h3>
+
+<h3 id="with-code">with <code>code</code></h3>
+
+<h3 id="with-nbspaumlnbspspace">with  ä space</h3>
+
+<h3 id="with-smart-quotes">With “smart” quotes</h3>
+
+<h3 id="with------typographic---symbols">with — « typographic » … symbols</h3>
+
+<h3 id="with-m5">with \(m=5\)</h3>

--- a/test/testcases/header_ids_with_transliteration.html
+++ b/test/testcases/header_ids_with_transliteration.html
@@ -14,11 +14,11 @@
 
 <h3 id="section-1">;;</h3>
 
-<h3 id="before-after-tab">before        after tab</h3>
+<h3 id="before-after-tab">before 	after tab</h3>
 
 <h3 id="with-code">with <code>code</code></h3>
 
-<h3 id="with-nbspaumlnbspspace">with  ä space</h3>
+<h3 id="with--a-space">with  ä space</h3>
 
 <h3 id="with-smart-quotes">With “smart” quotes</h3>
 

--- a/test/testcases/header_ids_with_transliteration.options
+++ b/test/testcases/header_ids_with_transliteration.options
@@ -1,0 +1,2 @@
+:auto_ids: true
+:transliterated_header_ids: true

--- a/test/testcases/header_ids_with_transliteration.text
+++ b/test/testcases/header_ids_with_transliteration.text
@@ -1,0 +1,27 @@
+### test {#myid}
+
+### variable_name
+
+### abc def öúß
+
+### 192 abc 192
+
+### ;.;;
+
+### variable_name
+
+### variable_name
+
+### ;;
+
+### before 	after tab
+
+### with `code`
+
+### with &nbsp;&auml;&nbsp;space
+
+### With "smart" quotes
+
+### with --- << typographic >> ... symbols
+
+### with $$m=5$$


### PR DESCRIPTION
A possible fix for #21 

While the IDs don't perfectly match what we see from the kramdown parser, they are all transliterated by kramdown's HTML converter.

One line that isn't exactly the same (all with transliterated_header_ids set to true) :

Current GFM parser:
`<h3 id="with-äspace">with  ä space</h3>`
Current kramdown parser:
`<h3 id="with-nbspaumlnbspspace">with  ä space</h3>`
This PR:
`<h3 id="with--a-space">with  ä space</h3>`

All other test case lines are the same as the kramdown parser.

By not setting an ID in the parser, we'll trigger the converter to add one (which is what happens with the kramdown parser):
https://github.com/gettalong/kramdown/blob/master/lib/kramdown/converter/html.rb#L143