### PR TITLE
Link to "GFM" docs early on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kramdown GFM parser
 
 This is a parser for [kramdown](https://kramdown.gettalong.org) that converts Markdown documents
-in the GFM dialect to HTML.
+in the [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/) dialect to HTML.
 
 Note: Until kramdown version 2.0.0 this parser was part of the kramdown distribution.
 


### PR DESCRIPTION
This bit of information is a bit buried lower down in the README and it
took me a while to understand what this parser was for as a result.

There also wasn't a link to the GFM spec, so I've added that too.