### PR TITLE
Fix emoji parser for +1 emoji

### DIFF
--- a/lib/kramdown/parser/gfm/emoji_parser.rb
+++ b/lib/kramdown/parser/gfm/emoji_parser.rb
@@ -15,7 +15,7 @@ module Kramdown
 
       EMOJI_NAMES   = Emoji.all.flat_map(&:aliases).freeze
       REGISTRY      = EMOJI_NAMES.zip(EMOJI_NAMES).to_h.freeze
-      EMOJI_PATTERN = /:(\w+):/
+      EMOJI_PATTERN = /:([\w\+]+):/
 
       # Based on the path rendered by `jemoji` plugin on GitHub Pages.
       DEFAULT_ASSET_PATH = 'https://github.githubassets.com/images/icons/emoji'

--- a/test/testcases/codeblock_fenced.html
+++ b/test/testcases/codeblock_fenced.html
@@ -16,5 +16,5 @@ Kramdown::Document.new(text).to_html
 
 <p>indent with 2 spaces</p>
 
-<div class="language-js highlighter-rouge"><div class="highlight"><pre class="highlight"><code>  <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="dl">"</span><span class="s2">hello</span><span class="dl">"</span><span class="p">);</span>
+<div class="language-js highlighter-rouge"><div class="highlight"><pre class="highlight"><code>  <span class="nx">console</span><span class="p">.</span><span class="nf">log</span><span class="p">(</span><span class="dl">"</span><span class="s2">hello</span><span class="dl">"</span><span class="p">);</span>
 </code></pre></div></div>

--- a/test/testcases/emoji.html
+++ b/test/testcases/emoji.html
@@ -1,5 +1,9 @@
 <p>Lorem ipsum dolor <img class="emoji" title=":smile:" alt=":smile:" src="https://github.githubassets.com/images/icons/emoji/unicode/1f604.png" height="20" width="20" /> sit amet</p>
 
+<p>Lorem ipsum dolor <img class="emoji" title=":+1:" alt=":+1:" src="https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png" height="20" width="20" /> sit amet</p>
+
+<p>Lorem ipsum dolor <img class="emoji" title=":100:" alt=":100:" src="https://github.githubassets.com/images/icons/emoji/unicode/1f4af.png" height="20" width="20" /> sit amet</p>
+
 <p>Lorem ipsum dolor :custom: sit amet</p>
 
 <p>Lorem ipsum dolor <code>:smile:</code> sit amet</p>

--- a/test/testcases/emoji.text
+++ b/test/testcases/emoji.text
@@ -1,5 +1,9 @@
 Lorem ipsum dolor :smile: sit amet
 
+Lorem ipsum dolor :+1: sit amet
+
+Lorem ipsum dolor :100: sit amet
+
 Lorem ipsum dolor :custom: sit amet
 
 Lorem ipsum dolor `:smile:` sit amet


### PR DESCRIPTION
```ruby
Kramdown::Document.new("i am :smile: because this PR is :+1:", input: "GFM", gfm_emojis: true).to_html
```

Fixes a bug where the 😄 emoji is correctly output, but the 👍 is not.