### PR TITLE
Callouts support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -252,7 +252,7 @@ module Kramdown
         end
 
         # Create callout container
-        callout_class = "markdown-alert markdown-alert-#{callout_type.downcase}"
+        callout_class = "callout callout-#{callout_type.downcase}"
         el = Element.new(:html_element, 'div', {'class' => callout_class},
                         category: :block, line: line_number)
         @tree.children << el

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -257,14 +257,6 @@ module Kramdown
                         category: :block, line: line_number)
         @tree.children << el
 
-        # Add title element
-        title_el = Element.new(:html_element, 'p', {'class' => 'markdown-alert-title'},
-                              category: :block, line: line_number)
-        el.children << title_el
-        title_text = Element.new(:text, callout_type.capitalize, nil,
-                                location: line_number)
-        title_el.children << title_text
-
         # Parse content as markdown
         content = content_lines.join("\n")
         unless content.strip.empty?

--- a/test/testcases/callouts.html
+++ b/test/testcases/callouts.html
@@ -1,44 +1,44 @@
 <h1>Single-line callouts</h1>
 
-<div class="markdown-alert markdown-alert-note">  <p>Useful information that users should know, even when skimming content.</p>
+<div class="callout callout-note">  <p>Useful information that users should know, even when skimming content.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-tip">  <p>Helpful advice for doing things better or more easily.</p>
+<div class="callout callout-tip">  <p>Helpful advice for doing things better or more easily.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-important">  <p>Key information users need to know to achieve their goal.</p>
+<div class="callout callout-important">  <p>Key information users need to know to achieve their goal.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-warning">  <p>Urgent info that needs immediate user attention to avoid problems.</p>
+<div class="callout callout-warning">  <p>Urgent info that needs immediate user attention to avoid problems.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-caution">  <p>Advises about risks or negative outcomes of certain actions.</p>
+<div class="callout callout-caution">  <p>Advises about risks or negative outcomes of certain actions.</p>
 </div>
 
 <h1>Multi-line callouts</h1>
 
-<div class="markdown-alert markdown-alert-note">  <p>This is a multi-line note.</p>
+<div class="callout callout-note">  <p>This is a multi-line note.</p>
 
   <p>It has multiple paragraphs.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-tip">  <p>Line one
+<div class="callout callout-tip">  <p>Line one
 Line two
 Line three</p>
 </div>
 
 <h1>Callouts with markdown content</h1>
 
-<div class="markdown-alert markdown-alert-important">  <p>This has <strong>bold</strong> and <em>italic</em> text.</p>
+<div class="callout callout-important">  <p>This has <strong>bold</strong> and <em>italic</em> text.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-warning">  <p>This has a <a href="https://example.com">link</a>.</p>
+<div class="callout callout-warning">  <p>This has a <a href="https://example.com">link</a>.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-note">  <p>This has <code>inline code</code>.</p>
+<div class="callout callout-note">  <p>This has <code>inline code</code>.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-note">  <p>This has a list:</p>
+<div class="callout callout-note">  <p>This has a list:</p>
 
   <ul>
     <li>Item 1</li>
@@ -58,23 +58,23 @@ It should not be a callout.</p>
 
 <p>Some text before.</p>
 
-<div class="markdown-alert markdown-alert-caution">  <p>Be careful with this operation.</p>
+<div class="callout callout-caution">  <p>Be careful with this operation.</p>
 </div>
 
 <p>Some text after.</p>
 
 <h1>Callout immediately followed by content</h1>
 
-<div class="markdown-alert markdown-alert-note">  <p>Important note here.</p>
+<div class="callout callout-note">  <p>Important note here.</p>
 </div>
 
 <p>Next paragraph.</p>
 
 <h1>Empty content after callout marker</h1>
 
-<div class="markdown-alert markdown-alert-tip"></div>
+<div class="callout callout-tip"></div>
 
 <h1>Only first line content</h1>
 
-<div class="markdown-alert markdown-alert-warning">  <p>This is all on one line.</p>
+<div class="callout callout-warning">  <p>This is all on one line.</p>
 </div>

--- a/test/testcases/callouts.html
+++ b/test/testcases/callouts.html
@@ -1,0 +1,95 @@
+<h1>Single-line callouts</h1>
+
+<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
+  <p>Useful information that users should know, even when skimming content.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-tip">  <p class="markdown-alert-title">Tip</p>
+  <p>Helpful advice for doing things better or more easily.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-important">  <p class="markdown-alert-title">Important</p>
+  <p>Key information users need to know to achieve their goal.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-warning">  <p class="markdown-alert-title">Warning</p>
+  <p>Urgent info that needs immediate user attention to avoid problems.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-caution">  <p class="markdown-alert-title">Caution</p>
+  <p>Advises about risks or negative outcomes of certain actions.</p>
+</div>
+
+<h1>Multi-line callouts</h1>
+
+<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
+  <p>This is a multi-line note.</p>
+
+  <p>It has multiple paragraphs.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-tip">  <p class="markdown-alert-title">Tip</p>
+  <p>Line one
+Line two
+Line three</p>
+</div>
+
+<h1>Callouts with markdown content</h1>
+
+<div class="markdown-alert markdown-alert-important">  <p class="markdown-alert-title">Important</p>
+  <p>This has <strong>bold</strong> and <em>italic</em> text.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-warning">  <p class="markdown-alert-title">Warning</p>
+  <p>This has a <a href="https://example.com">link</a>.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
+  <p>This has <code>inline code</code>.</p>
+</div>
+
+<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
+  <p>This has a list:</p>
+
+  <ul>
+    <li>Item 1</li>
+    <li>Item 2</li>
+    <li>Item 3</li>
+  </ul>
+</div>
+
+<h1>Regular blockquotes still work</h1>
+
+<blockquote>
+  <p>This is a regular blockquote.<br />
+It should not be a callout.</p>
+</blockquote>
+
+<h1>Mixed content</h1>
+
+<p>Some text before.</p>
+
+<div class="markdown-alert markdown-alert-caution">  <p class="markdown-alert-title">Caution</p>
+  <p>Be careful with this operation.</p>
+</div>
+
+<p>Some text after.</p>
+
+<h1>Callout immediately followed by content</h1>
+
+<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
+  <p>Important note here.</p>
+</div>
+
+<p>Next paragraph.</p>
+
+<h1>Empty content after callout marker</h1>
+
+<div class="markdown-alert markdown-alert-tip">  <p class="markdown-alert-title">Tip</p>
+</div>
+
+<h1>Only first line content</h1>
+
+<div class="markdown-alert markdown-alert-warning">  <p class="markdown-alert-title">Warning</p>
+  <p>This is all on one line.</p>
+</div>

--- a/test/testcases/callouts.html
+++ b/test/testcases/callouts.html
@@ -1,55 +1,44 @@
 <h1>Single-line callouts</h1>
 
-<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
-  <p>Useful information that users should know, even when skimming content.</p>
+<div class="markdown-alert markdown-alert-note">  <p>Useful information that users should know, even when skimming content.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-tip">  <p class="markdown-alert-title">Tip</p>
-  <p>Helpful advice for doing things better or more easily.</p>
+<div class="markdown-alert markdown-alert-tip">  <p>Helpful advice for doing things better or more easily.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-important">  <p class="markdown-alert-title">Important</p>
-  <p>Key information users need to know to achieve their goal.</p>
+<div class="markdown-alert markdown-alert-important">  <p>Key information users need to know to achieve their goal.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-warning">  <p class="markdown-alert-title">Warning</p>
-  <p>Urgent info that needs immediate user attention to avoid problems.</p>
+<div class="markdown-alert markdown-alert-warning">  <p>Urgent info that needs immediate user attention to avoid problems.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-caution">  <p class="markdown-alert-title">Caution</p>
-  <p>Advises about risks or negative outcomes of certain actions.</p>
+<div class="markdown-alert markdown-alert-caution">  <p>Advises about risks or negative outcomes of certain actions.</p>
 </div>
 
 <h1>Multi-line callouts</h1>
 
-<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
-  <p>This is a multi-line note.</p>
+<div class="markdown-alert markdown-alert-note">  <p>This is a multi-line note.</p>
 
   <p>It has multiple paragraphs.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-tip">  <p class="markdown-alert-title">Tip</p>
-  <p>Line one
+<div class="markdown-alert markdown-alert-tip">  <p>Line one
 Line two
 Line three</p>
 </div>
 
 <h1>Callouts with markdown content</h1>
 
-<div class="markdown-alert markdown-alert-important">  <p class="markdown-alert-title">Important</p>
-  <p>This has <strong>bold</strong> and <em>italic</em> text.</p>
+<div class="markdown-alert markdown-alert-important">  <p>This has <strong>bold</strong> and <em>italic</em> text.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-warning">  <p class="markdown-alert-title">Warning</p>
-  <p>This has a <a href="https://example.com">link</a>.</p>
+<div class="markdown-alert markdown-alert-warning">  <p>This has a <a href="https://example.com">link</a>.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
-  <p>This has <code>inline code</code>.</p>
+<div class="markdown-alert markdown-alert-note">  <p>This has <code>inline code</code>.</p>
 </div>
 
-<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
-  <p>This has a list:</p>
+<div class="markdown-alert markdown-alert-note">  <p>This has a list:</p>
 
   <ul>
     <li>Item 1</li>
@@ -69,27 +58,23 @@ It should not be a callout.</p>
 
 <p>Some text before.</p>
 
-<div class="markdown-alert markdown-alert-caution">  <p class="markdown-alert-title">Caution</p>
-  <p>Be careful with this operation.</p>
+<div class="markdown-alert markdown-alert-caution">  <p>Be careful with this operation.</p>
 </div>
 
 <p>Some text after.</p>
 
 <h1>Callout immediately followed by content</h1>
 
-<div class="markdown-alert markdown-alert-note">  <p class="markdown-alert-title">Note</p>
-  <p>Important note here.</p>
+<div class="markdown-alert markdown-alert-note">  <p>Important note here.</p>
 </div>
 
 <p>Next paragraph.</p>
 
 <h1>Empty content after callout marker</h1>
 
-<div class="markdown-alert markdown-alert-tip">  <p class="markdown-alert-title">Tip</p>
-</div>
+<div class="markdown-alert markdown-alert-tip"></div>
 
 <h1>Only first line content</h1>
 
-<div class="markdown-alert markdown-alert-warning">  <p class="markdown-alert-title">Warning</p>
-  <p>This is all on one line.</p>
+<div class="markdown-alert markdown-alert-warning">  <p>This is all on one line.</p>
 </div>

--- a/test/testcases/callouts.text
+++ b/test/testcases/callouts.text
@@ -1,0 +1,75 @@
+# Single-line callouts
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+# Multi-line callouts
+
+> [!NOTE]
+> This is a multi-line note.
+>
+> It has multiple paragraphs.
+
+> [!TIP]
+> Line one
+> Line two
+> Line three
+
+# Callouts with markdown content
+
+> [!IMPORTANT]
+> This has **bold** and *italic* text.
+
+> [!WARNING]
+> This has a [link](https://example.com).
+
+> [!NOTE]
+> This has `inline code`.
+
+> [!NOTE]
+> This has a list:
+>
+> - Item 1
+> - Item 2
+> - Item 3
+
+# Regular blockquotes still work
+
+> This is a regular blockquote.
+> It should not be a callout.
+
+# Mixed content
+
+Some text before.
+
+> [!CAUTION]
+> Be careful with this operation.
+
+Some text after.
+
+# Callout immediately followed by content
+
+> [!NOTE]
+> Important note here.
+
+Next paragraph.
+
+# Empty content after callout marker
+
+> [!TIP]
+
+# Only first line content
+
+> [!WARNING] This is all on one line.

--- a/test/testcases/codeblock_fenced.html
+++ b/test/testcases/codeblock_fenced.html
@@ -16,5 +16,5 @@ Kramdown::Document.new(text).to_html
 
 <p>indent with 2 spaces</p>
 
-<div class="language-js highlighter-rouge"><div class="highlight"><pre class="highlight"><code>  <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="dl">"</span><span class="s2">hello</span><span class="dl">"</span><span class="p">);</span>
+<div class="language-js highlighter-rouge"><div class="highlight"><pre class="highlight"><code>  <span class="nx">console</span><span class="p">.</span><span class="nf">log</span><span class="p">(</span><span class="dl">"</span><span class="s2">hello</span><span class="dl">"</span><span class="p">);</span>
 </code></pre></div></div>


### PR DESCRIPTION
Callouts, also called Alerts or Admonitions, define a consistent formatting for stand-out elements:

> [!NOTE]  
> Highlights information that users should take into account, even when skimming.

> [!TIP]
> Optional information to help a user be more successful.

> [!IMPORTANT]  
> Crucial information necessary for users to succeed.

> [!WARNING]  
> Critical content demanding immediate user attention due to potential risks.

> [!CAUTION]
> Negative potential consequences of an action.

Despite their are not an official markdown specification, over the years the style has converged over:

```
> [!NOTE]  
> Highlights information that users should take into account, even when skimming.

> [!TIP]
> Optional information to help a user be more successful.

> [!IMPORTANT]  
> Crucial information necessary for users to succeed.

> [!WARNING]  
> Critical content demanding immediate user attention due to potential risks.

> [!CAUTION]
> Negative potential consequences of an action.
```

Multiple tools have adopted this syntax that is now widely considered a de-facto standard:

- Github: https://github.com/orgs/community/discussions/16925 and https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
- Obsidian: https://help.obsidian.md/callouts

This PR adds support for callouts. Implemented as an additional extension, per https://github.com/gettalong/kramdown/issues/300#issuecomment-853911220.